### PR TITLE
Ignore all directories that begin with output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-output/
+output*/


### PR DESCRIPTION
If you want to save output directories and rename them to something like `output_wave` or `output_step` now you can.